### PR TITLE
Clear persistence context after each incremental indexing loop

### DIFF
--- a/common/src/pandas/search/SearchScheduler.java
+++ b/common/src/pandas/search/SearchScheduler.java
@@ -129,6 +129,8 @@ public class SearchScheduler {
             } catch (Exception e) {
                 entityManager.getTransaction().rollback();
                 throw e;
+            } finally {
+                entityManager.clear();
             }
         }
 
@@ -172,6 +174,8 @@ public class SearchScheduler {
             } catch (Exception e) {
                 entityManager.getTransaction().rollback();
                 throw e;
+            } finally {
+                entityManager.clear();
             }
         }
         ;
@@ -225,6 +229,8 @@ public class SearchScheduler {
                 } catch (Exception e) {
                     entityManager.getTransaction().rollback();
                     throw e;
+                } finally {
+                    entityManager.clear();
                 }
             }
         }


### PR DESCRIPTION
This is intended to address an issue where it appears as if a background modification can change lastModifiedDate in the database, while Hibernate hangs onto the old value, leading to an infinite loop reindexing the same records repeatedly. Clearing the persistence context should ensure each entity is loaded fresh in each iteration. This may also reduce memory usage during indexing.